### PR TITLE
Limit image width to 100%

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -14,6 +14,11 @@ table td, table th {
   border-right: 1px solid #ccc;
 }
 
+img {
+  max-width: 100%; 
+  /* Github's markdown renderer has this too, this will probably help a lot of people */
+}
+
 .container {
   min-height: 100%;
   width: 100%;


### PR DESCRIPTION
Github's Markdown viewer does this also. Not doing this will cause several chapters to be too wide.
