### PR TITLE
[WIP] Add script for generating simple EPUB file using pandoc

### DIFF
--- a/generate_ebook.sh
+++ b/generate_ebook.sh
@@ -1,0 +1,13 @@
+TITLE="Delft Students on Software Architecture"
+
+pandoc -S --toc --toc-depth=2 --epub-cover-image=css/cover.jpg -o "${TITLE}.epub" title.txt \
+  chapters/syncany/index.md \
+  chapters/openra/index.md \
+  chapters/playframework/index.md \
+  chapters/angulardart/index.md \
+  chapters/docker/index.md \
+  chapters/diaspora/index.md \
+  chapters/vagrant/index.md \
+  chapters/jekyll/index.md \
+  chapters/joomla/index.md \
+  chapters/kodi/index.md


### PR DESCRIPTION
This pull request adds a simple script for generating an epub file using pandoc (http://pandoc.org/). This file can be viewed on different ebook readers.

The pull request is still work in progress. There are some open issues left:
1. Ideally, I could get access to the bigger cover image.
2. I need to fix some Markdown formatting in the chapters - currently, not all of the chapters use the consistent header styles which results in an incorrect grouping in the generated ebook.
3. Need to hook up generate task inside Vagrant.
